### PR TITLE
Add k3OS Config Operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y \
-    wget parted dosfstools binutils p7zip-full \
+    wget parted udev dosfstools binutils p7zip-full \
     sudo xz-utils jq u-boot-tools
 
 # The repository should be mounted at /app.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-picl-builder-image build-img deploy-k3os-config
+.PHONY: build-picl-builder-image build-img deploy-k3os-config update-k3osconfig-secret
 
 build-picl-builder-image:
 	docker build . -t picl-builder:latest
@@ -6,5 +6,8 @@ build-picl-builder-image:
 build-img:
 	docker run -e K3OS_VERSION=v0.11.1 -e TARGET=raspberrypi -e RASPBERRY_PI_FIRMWARE=latest -v ${PWD}:/app -v /dev:/dev --privileged picl-builder:latest
 
-deploy-k3os-config:
+deploy-k3os-config: update-k3osconfig-secret
 	kustomize build k8s | kubectl apply -f -
+
+update-k3osconfig-secret:
+	docker run -v ${PWD}/config:/config ghcr.io/annismckenzie/k3os-config-operator/tools:v0.1.1-3-g387ede9

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build-img
+
+build-img:
+	docker run -e K3OS_VERSION=v0.11.1 -e TARGET=raspberrypi -e RASPBERRY_PI_FIRMWARE=latest -v ${PWD}:/app -v /dev:/dev --privileged picl-builder:latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build-img deploy-k3os-config
+.PHONY: build-picl-builder-image build-img deploy-k3os-config
+
+build-picl-builder-image:
+	docker build . -t picl-builder:latest
 
 build-img:
 	docker run -e K3OS_VERSION=v0.11.1 -e TARGET=raspberrypi -e RASPBERRY_PI_FIRMWARE=latest -v ${PWD}:/app -v /dev:/dev --privileged picl-builder:latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build-img
+.PHONY: build-img deploy-k3os-config
 
 build-img:
 	docker run -e K3OS_VERSION=v0.11.1 -e TARGET=raspberrypi -e RASPBERRY_PI_FIRMWARE=latest -v ${PWD}:/app -v /dev:/dev --privileged picl-builder:latest
+
+deploy-k3os-config:
+	kustomize build k8s | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ building on a Mac or Windows.
 If you want to build in Docker, you can build a container containing the dependencies using:
 
 ```
-docker build . -t picl-builder:latest
+make build-picl-builder-image
 ```
 
 Then, run the container using:

--- a/build-image.sh
+++ b/build-image.sh
@@ -206,6 +206,7 @@ sudo e2label $LODEV_ROOT "root"
 
 ## Initialize root
 echo "== Initializing root... =="
+rm -rf root
 mkdir root
 sudo mount $LODEV_ROOT root
 sudo mkdir root/bin root/boot root/dev root/etc root/home root/lib root/media
@@ -223,6 +224,7 @@ if [ "$IMAGE_TYPE" = "raspberrypi" ]; then
 	PITEMP="$(mktemp -d)"
 	sudo tar -xf deps/raspberrypi-firmware.tar.gz --strip 1 -C $PITEMP
 
+	rm -rf boot
 	mkdir boot
 	sudo mount $LODEV_BOOT boot
 	sudo cp -R $PITEMP/boot/* boot

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+  - ../../config/

--- a/k8s/k3osconfig.yaml
+++ b/k8s/k3osconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.operators.annismckenzie.github.com/v1alpha1
+kind: K3OSConfig
+metadata:
+  name: default
+spec:
+  syncNodeLabels: true
+  syncNodeTaints: false

--- a/k8s/k3osconfig.yaml
+++ b/k8s/k3osconfig.yaml
@@ -2,6 +2,7 @@ apiVersion: config.operators.annismckenzie.github.com/v1alpha1
 kind: K3OSConfig
 metadata:
   name: default
+  namespace: k3os-config-operator-system
 spec:
   syncNodeLabels: true
   syncNodeTaints: false

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,5 +1,3 @@
-namespace: k3os-config-operator-system
-
 bases:
   - base/
 

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,7 @@
+namespace: k3os-config-operator-system
+
+bases:
+  - base/
+
+resources:
+  - k3osconfig.yaml


### PR DESCRIPTION
This is a draft for adding my K3OS Config Operator to the project.

TODO:
- [ ] add `update_k3osnodes_secret` CLI tool
- [ ] allow a specific version to be included in the manifests of the compiled image so the operator is ready to go when booting up k3OS (probably needs to be added in the `build-image.sh` shell script using a parameter/environment variable)
- [ ] add documentation to the README on how this all works

For anyone wanting to give this a whirl:
- clone this repo, check out this branch, put your `[MAC address].yaml` files into the config directory
- create a `kustomization.yaml` file in the config directory:
```
namespace: k3os-config-operator-system

secretGenerator:
  - name: k3os-nodes
    files:
      - master-hostname=[MAC address].yaml # master-hostname
      - node-hostname=[MAC address].yaml   # node-hostname
      - …
    type: Opaque

generatorOptions:
  labels:
    app.kubernetes.io/managed-by: k3os-config-operator
  disableNameSuffixHash: true
```
(the comments in the line at the ends are just for reference)
- run `make deploy-k3os-config`

The deploy the k3OS Config Operator as outlined here: https://github.com/annismckenzie/k3os-config-operator#installation.

To also sync node taints (the version that's in this PR only enables syncing node labels) can be enabled in the `k8s/k3osconfig.yaml` file.

All of the manual steps will be done by the `update_k3osnodes_secret` CLI tool so that in the end you only have to bring your `config` directory of YAML files.

To update your node labels and taints, just update your YAML files, run `make deploy-k3os-config` again and that's it.